### PR TITLE
Add CSS style sheet with @font-face declaration

### DIFF
--- a/webfonts/Prociono.css
+++ b/webfonts/Prociono.css
@@ -10,7 +10,7 @@
 */
 @font-face {
   font-family: 'Prociono';
-  src: url('Prociono-Regular-webfont.eot'),
+  src: url('Prociono-Regular-webfont.eot');
   src: url('Prociono-Regular-webfont.eot?#iefix') format('embedded-opentype'),
        url('Prociono-Regular-webfont.woff') format('woff'),
        url('Prociono-Regular-webfont.ttf')  format('truetype'),

--- a/webfonts/Prociono.css
+++ b/webfonts/Prociono.css
@@ -10,6 +10,7 @@
 */
 @font-face {
   font-family: 'Prociono';
+  src: url('Prociono-Regular-webfont.eot'),
   src: url('Prociono-Regular-webfont.eot?#iefix') format('embedded-opentype'),
        url('Prociono-Regular-webfont.woff') format('woff'),
        url('Prociono-Regular-webfont.ttf')  format('truetype'),

--- a/webfonts/Prociono.css
+++ b/webfonts/Prociono.css
@@ -1,0 +1,17 @@
+/*
+  'Prociono'
+  https://www.theleagueofmoveabletype.com/prociono
+
+  Copyright (c) 2009, Barry Schwartz <site-chieftain@crudfactory.com>,
+  with Reserved Font Name OFL "Prociono".
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  http://scripts.sil.org/OFL
+*/
+@font-face {
+  font-family: 'Prociono';
+  src: url('Prociono-Regular-webfont.eot?#iefix') format('embedded-opentype'),
+       url('Prociono-Regular-webfont.woff') format('woff'),
+       url('Prociono-Regular-webfont.ttf')  format('truetype'),
+       url('Prociono-Regular-webfont.svg#webfontLqDKYAnt') format('svg');
+}


### PR DESCRIPTION
The format used for the @font-face declaration is the
"Fontspring @Font-Face Syntax"[1] considered [2]
"the most simple and compatible one".

[1] The New Bulletproof @Font-Face Syntax
2011-02-03 (last updated: 2011-04-21)
http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax

[2] The @Font-Face Rule And Useful Web Font Tricks
2011-03-02, by Ralf Hermann
http://www.smashingmagazine.com/2011/03/02/the-font-face-rule-revisited-and-useful-tricks/
